### PR TITLE
Update spec and src to comply with Sulfuras quality rules

### DIFF
--- a/spec/GildedRoseSpec.php
+++ b/spec/GildedRoseSpec.php
@@ -127,7 +127,7 @@ describe('Gilded Rose', function () {
 
                 $item->tick();
 
-                expect($item->quality)->toBe(10);
+                expect($item->quality)->toBe(80);
                 expect($item->sellIn)->toBe(5);
             });
 
@@ -136,7 +136,7 @@ describe('Gilded Rose', function () {
 
                 $item->tick();
 
-                expect($item->quality)->toBe(10);
+                expect($item->quality)->toBe(80);
                 expect($item->sellIn)->toBe(5);
             });
 
@@ -145,8 +145,14 @@ describe('Gilded Rose', function () {
 
                 $item->tick();
 
-                expect($item->quality)->toBe(10);
+                expect($item->quality)->toBe(80);
                 expect($item->sellIn)->toBe(-1);
+            });
+
+            it ('ensures Sulfuras item quality before tick', function() {
+                $item = GildedRose::of('Sulfuras, Hand of Ragnaros', 10, 5);
+
+                expect($item->quality)->toBe(80);
             });
 
         });

--- a/src/GildedRose.php
+++ b/src/GildedRose.php
@@ -12,6 +12,9 @@ class GildedRose
 
     public function __construct($name, $quality, $sellIn)
     {
+        if ($name == 'Sulfuras, Hand of Ragnaros') {
+            $quality = 80;
+        }
         $this->name = $name;
         $this->quality = $quality;
         $this->sellIn = $sellIn;


### PR DESCRIPTION
The tests and src were not following the rules of Sulfuras' legendary quality rules, which state:

> Just for clarification, an item can never have its Quality increase above 50, however "Sulfuras" is a legendary item and as such its Quality is 80 and it never alters.
